### PR TITLE
Fix agent skills navigation redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,11 +8,11 @@
 (function () {
   var oldPrefix = "/agent-skills";
   if (window.location.pathname === oldPrefix || window.location.pathname.indexOf(oldPrefix + "/") === 0) {
-    var newBase = "https://hugobowne.github.io/show-us-your-agent-skills/";
+    var newBase = "https://hugobowne.github.io/agent-skills.html";
     var rest = window.location.pathname.replace(/^\/agent-skills\/?/, "").replace(/^\/+/, "");
-    var target = new URL(rest ? "agent-skills/" + rest : "", newBase);
+    var target = new URL(newBase);
     target.search = window.location.search;
-    target.hash = window.location.hash;
+    target.hash = window.location.hash || (rest ? "#" + rest : "");
     window.location.replace(target.href);
   }
 }());
@@ -37,7 +37,7 @@ a { color: #8df36c; }
 <body>
 <main>
   <h1>Page not found</h1>
-  <p>The agent skills site moved to <a href="https://hugobowne.github.io/show-us-your-agent-skills/">hugobowne.github.io/show-us-your-agent-skills</a>.</p>
+  <p>The agent skills site moved to <a href="https://hugobowne.github.io/agent-skills.html">hugobowne.github.io/agent-skills.html</a>.</p>
 </main>
 </body>
 </html>

--- a/agent-skills.html
+++ b/agent-skills.html
@@ -3,23 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<script>
-(function () {
-  var newBase = "https://hugobowne.github.io/show-us-your-agent-skills/";
-  var rest = window.location.pathname.replace(/^\/agent-skills\/?/, "").replace(/^\/+/, "");
-  var target = new URL(rest ? "agent-skills/" + rest : "", newBase);
-  target.search = window.location.search;
-  target.hash = window.location.hash;
-  window.location.replace(target.href);
-}());
-</script>
 <title>Show Us Your Agent Skills · Hugo Bowne-Anderson</title>
 <meta name="description" content="Long-time Python, ML, and AI builders show how they're actually using agents today — real workflows, agent skills, harnesses. Vanishing Gradients × PyMC Labs, live on YouTube.">
 <meta name="author" content="Hugo Bowne-Anderson">
-<link rel="canonical" href="https://hugobowne.github.io/agent-skills">
+<link rel="canonical" href="https://hugobowne.github.io/agent-skills.html">
 
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://hugobowne.github.io/agent-skills">
+<meta property="og:url" content="https://hugobowne.github.io/agent-skills.html">
 <meta property="og:title" content="Show Us Your Agent Skills · Vanishing Gradients × PyMC Labs">
 <meta property="og:description" content="Long-time Python, ML, and AI builders show how they're actually using agents today. Not vibe coding. Not demos. The real workflows.">
 <meta property="og:site_name" content="hugo-bowne-anderson.ai">
@@ -761,13 +751,13 @@ a.rcard:hover {
 
 <header class="topbar">
   <div class="page">
-    <div class="logo"><a href="index.html" style="color:inherit">hugo-bowne-anderson<span class="dot">.</span>ai</a></div>
+    <div class="logo"><a href="/" style="color:inherit">hugo-bowne-anderson<span class="dot">.</span>ai</a></div>
     <nav>
-      <a href="index.html#podcasts">podcasts</a>
-      <a href="index.html#writing">writing</a>
-      <a href="index.html#workshops">workshops</a>
-      <a href="agent-skills" class="active">agent skills</a>
-      <a href="index.html#course">building agents</a>
+      <a href="/#podcasts">podcasts</a>
+      <a href="/#writing">writing</a>
+      <a href="/#workshops">workshops</a>
+      <a href="/agent-skills.html" class="active">agent skills</a>
+      <a href="/#course">building agents</a>
     </nav>
     <div class="status">thu · ep 05 · jun 18</div>
   </div>

--- a/agent-skills/index.html
+++ b/agent-skills/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Show Us Your Agent Skills moved</title>
-<link rel="canonical" href="https://hugobowne.github.io/show-us-your-agent-skills/">
+<link rel="canonical" href="https://hugobowne.github.io/agent-skills.html">
 <script>
 (function () {
-  var target = new URL("https://hugobowne.github.io/show-us-your-agent-skills/");
+  var target = new URL("https://hugobowne.github.io/agent-skills.html");
   target.search = window.location.search;
   target.hash = window.location.hash;
   window.location.replace(target.href);
@@ -15,6 +15,6 @@
 </script>
 </head>
 <body>
-<p>This page has moved to <a href="https://hugobowne.github.io/show-us-your-agent-skills/">hugobowne.github.io/show-us-your-agent-skills</a>.</p>
+<p>This page has moved to <a href="https://hugobowne.github.io/agent-skills.html">hugobowne.github.io/agent-skills.html</a>.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -439,7 +439,7 @@ body {
       <a href="#podcasts">podcasts</a>
       <a href="#writing">writing</a>
       <a href="#workshops">workshops</a>
-      <a href="https://hugobowne.github.io/show-us-your-agent-skills/">agent skills</a>
+      <a href="/agent-skills.html">agent skills</a>
       <a href="#course">building agents</a>
     </nav>
     <div style="display:flex;gap:14px;align-items:center">

--- a/show.html
+++ b/show.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8">
 <title>Show Us Your Agent Skills · Hugo Bowne-Anderson</title>
-<link rel="canonical" href="https://hugobowne.github.io/agent-skills">
+<link rel="canonical" href="https://hugobowne.github.io/agent-skills.html">
 <meta name="robots" content="noindex">
-<meta http-equiv="refresh" content="0; url=/agent-skills">
-<script>location.replace("/agent-skills" + location.hash);</script>
+<meta http-equiv="refresh" content="0; url=/agent-skills.html">
+<script>location.replace("/agent-skills.html" + location.hash);</script>
 </head>
 <body>
-<p>This page has moved to <a href="/agent-skills">hugobowne.github.io/agent-skills</a>.</p>
+<p>This page has moved to <a href="/agent-skills.html">hugobowne.github.io/agent-skills.html</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
Summary:
- remove the stale self-redirect from the live agent skills page
- point top nav links at the current agent-skills.html page and root homepage anchors
- update old redirect stubs away from show-us-your-agent-skills

Verification:
- opened http://localhost:8000/agent-skills.html in the in-app browser
- verified the active agent skills nav link stays on agent-skills.html
- verified the podcasts nav link lands on /#podcasts
- ran git diff --check